### PR TITLE
Augmente la visibilité des dispositifs locaux en YAML

### DIFF
--- a/app/js/constants/benefits/index.js
+++ b/app/js/constants/benefits/index.js
@@ -607,26 +607,6 @@ var droitsDescription = {
     }
 };
 
-function setDefaults(benefit, top) {
-    benefit.top = benefit.top || top;
-    benefit.floorAt = benefit.floorAt || 1;
-    benefit.entity = benefit.entity || 'famille';
-}
-
-var topLevels = {
-    prestationsNationales: 1,
-    partenairesLocaux: 5,
-};
-
-Object.keys(droitsDescription).forEach(function(levelId) {
-    Object.keys(droitsDescription[levelId]).forEach(function(providerId) {
-        Object.keys(droitsDescription[levelId][providerId].prestations).forEach(function(benefitId) {
-            var benefit = droitsDescription[levelId][providerId].prestations[benefitId];
-            setDefaults(benefit, topLevels[levelId]);
-        });
-    });
-});
-
 var msaAdditionProviders = [
     'assurance_retraite',
     'assurance_maladie',

--- a/app/js/constants/benefits/utils.js
+++ b/app/js/constants/benefits/utils.js
@@ -77,6 +77,17 @@ function extractExperimentations(institutions) {
   })
 }
 
+function setDefaults(benefit, top) {
+    benefit.top = benefit.top || top
+    benefit.floorAt = benefit.floorAt || 1
+    benefit.entity = benefit.entity || 'famille'
+}
+
+var topLevels = {
+    prestationsNationales: 1,
+    partenairesLocaux: 5,
+}
+
 function generate(jamstack, base) {
   const institutions = transformInstitutions(jamstack.collections.institutions.items)
   append(institutions, jamstack.collections.benefits.items)
@@ -86,6 +97,16 @@ function generate(jamstack, base) {
     partenairesLocaux: Object.assign(base.partenairesLocaux, institutions),
   }
   result.experimentations = extractExperimentations(result.partenairesLocaux)
+
+  const levels = ['prestationsNationales', 'partenairesLocaux']
+  levels.forEach(function(levelId) {
+      Object.keys(result[levelId]).forEach(function(providerId) {
+          Object.keys(result[levelId][providerId].prestations).forEach(function(benefitId) {
+              var benefit = result[levelId][providerId].prestations[benefitId]
+              setDefaults(benefit, topLevels[levelId])
+          })
+      })
+  })
 
   result.forEach = forEachFactory(result)
   return result


### PR DESCRIPTION
L'augmentation de la visibilité n'était fonctionnelle uniquement sur les dispositifs du fichier central. Les ajouts par fiche YAML n'étaient pas pris en compte.