### PR TITLE
Correct port conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       MAILJET_PRIVATE_KEY: ${MAILJET_PRIVATE_KEY}
     ports:
       - '35729:35729'
-      - '8080:8080'
       - '9001:9001'
     depends_on:
       - mongo


### PR DESCRIPTION
Actuellement il est impossible de démarrer avec `docker-compose up` car le port 8080 entre en conflit avec `node` et `nginx`.

> ERROR: for simulateur_nginx_1  Cannot start service nginx: driver failed programming external connectivity on endpoint simulateur_nginx_1 (a55cb1b1911fa95170641d9af779861afa85aed0034e0c3fd23baf117e829730): Bind for 0.0.0.0:8080 failed: port is already allocated

Il faut donc enlever celui de node et laisser la redirection de Nginx se faire.