### PR TITLE
Fix package.json removing unused dependency + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,18 @@ You will need [`pip`](https://pip.pypa.io/) to install Openfisca.
 
 Application
 -----------
-
+Run the following from the root of the project to install the dependencies
 ```sh
-git clone https://github.com/sgmap/mes-aides-ui.git
-cd mes-aides-ui
 npm install
 ```
 
 Openfisca
 ---------
+:warning: As of now, python3.9 is not yet compatible with all python packages used in Openfisca. It is recommend to use a lower version such as `3.8.6`.
 
 You should [install Python 3 in a `virtualenv`](https://virtualenv.pypa.io/en/stable/) to prevent yourself from messing with your main python installation. You can either create the `virtualenv` yourself or rely on tools such as [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) or [pew](https://github.com/berdario/pew):
 
 ```bash
-cd mes-aides-ui
 virtualenv  --python=python3 .venv # To create your virtualenv in ./.venv (a hidden folder)
 source .venv/bin/activate # To activate your virtualenv
 pip install pip --upgrade # To make sure you're using pip latest version

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "raven": "^2.6.4",
     "raven-js": "^3.27.2",
     "request-promise": "^4.2.5",
-    "sgmap-mes-aides-api": "github:sgmap/mes-aides-api#v12.0.0",
     "sib-api-v3-sdk": "^7.2.2",
     "smooth-scroll": "^16.1.3",
     "template.data.gouv.fr": "^1.3.2",


### PR DESCRIPTION
This branch removes the dependency to `sgmap-mes-aides-api` which is not used project wide. This removal makes possible the use of nodejs upper versions such as `v12.18.2` in my case.

It also provides a warning in `README.md` for devs using python3.9 as it is not supported in every python packages Openfisca uses (like pandas for instance).

Finally, it removes references to the old folder path `mes-aides-ui` in full installation steps as it is not relevant.