### PR TITLE
Répare la restitution avec évolution des ressources

### DIFF
--- a/backend/lib/openfisca/bulk/index.js
+++ b/backend/lib/openfisca/bulk/index.js
@@ -1,104 +1,104 @@
-var Promise = require('bluebird');
-var openfisca = Promise.promisifyAll(require('..'));
-var common = require('../mapping/common');
+var Promise = require('bluebird')
+var openfisca = Promise.promisifyAll(require('..'))
+var common = require('../mapping/common')
 
 var entityGroups = {
     individus: [],
     familles: ['parents', 'enfants'],
     foyers_fiscaux: ['declarants', 'personnes_a_charge'],
     menages: ['personne_de_reference', 'conjoint', 'enfants']
-};
+}
 
 function init() {
     var result = Object.keys(entityGroups).reduce((accum, entityName) => {
-        accum[entityName] = {};
-        return accum;
-    }, {});
-    result['individus'] = {};
+        accum[entityName] = {}
+        return accum
+    }, {})
+    result['individus'] = {}
 
-    return result;
+    return result
 }
 
 function prefix(prefix, situation) {
     Object.keys(entityGroups).forEach(entityName => {
-        var oldKeys = Object.keys(situation[entityName]);
+        var oldKeys = Object.keys(situation[entityName])
         oldKeys.forEach(name => {
-            situation[entityName][prefix + name] = situation[entityName][name];
-            delete situation[entityName][name];
-        });
+            situation[entityName][prefix + name] = situation[entityName][name]
+            delete situation[entityName][name]
+        })
 
         entityGroups[entityName].forEach(property => {
             Object.keys(situation[entityName]).forEach(id => {
-                let entity = situation[entityName][id];
+                let entity = situation[entityName][id]
 
                 if (entity[property]) {
-                    entity[property] =  entity[property].map(id => prefix + id);
+                    entity[property] =  entity[property].map(id => prefix + id)
                 }
-            });
-        });
-    });
+            })
+        })
+    })
 
-    return situation;
+    return situation
 }
 
 function append(acummulator, situation) {
     Object.keys(entityGroups).forEach(entityName => {
         Object.keys(situation[entityName]).forEach(id => {
-            acummulator[entityName][id] = situation[entityName][id];
-        });
-    });
+            acummulator[entityName][id] = situation[entityName][id]
+        })
+    })
 
-    return acummulator;
+    return acummulator
 }
 
-var defaultValues = [];
-var max = 3500;
-var base = 25;
-var steps = max/base + 1;
+var defaultValues = []
+var max = 3500
+var base = 25
+var steps = max/base + 1
 for (var i=0; i<steps; i = i+1) {
-    defaultValues.push(i * max / (steps-1));
+    defaultValues.push(i * max / (steps-1))
 }
 
 function build(situation, variable, values) {
     values = values || defaultValues
-    var periods = common.getPeriods(situation.dateDeValeur);
+    var periods = common.getPeriods(situation.dateDeValeur)
 
-    var fullTimePeriodLength = 12*4;
-    var fullTimePeriod = 'month:' + periods['3YearsAgo'] + ':' + fullTimePeriodLength.toString();
+    var fullTimePeriodLength = 12*4
+    var fullTimePeriod = 'month:' + periods['3YearsAgo'] + ':' + fullTimePeriodLength.toString()
 
     return values.reduce((a, v) => {
-            situation.demandeur[variable] = {};
-            situation.demandeur[variable][fullTimePeriod] = fullTimePeriodLength * v;
-            var ss = openfisca.buildOpenFiscaRequest(situation);
+            situation.demandeur[variable] = {}
+            situation.demandeur[variable][fullTimePeriod] = fullTimePeriodLength * v
+            var ss = openfisca.buildOpenFiscaRequest(situation)
 
-            ss.foyers_fiscaux._.irpp = { [periods.thisYear]: null };
+            ss.foyers_fiscaux._.irpp = { [periods.thisYear]: null }
 
-            var prefixed = prefix(v.toString() + '_', ss);
-            return append(a, prefixed);
+            var prefixed = prefix(v.toString() + '_', ss)
+            return append(a, prefixed)
         }, init())
 }
 
 function extractResults({ source, response }, benefitIds) {
-    var periods = common.getPeriods(source.dateDeValeur);
-    var entities = ['familles', 'individus', 'foyers_fiscaux', 'menages'];
+    var periods = common.getPeriods(source.dateDeValeur)
+    var entities = ['familles', 'individus', 'foyers_fiscaux', 'menages']
 
     return entities.reduce((groupAccum, group) => {
-        var entityNames = Object.keys(response[group]);
+        var entityNames = Object.keys(response[group])
         return entityNames.reduce((entityAccum, id) => {
-            var prefix = id.split('_')[0];
-            entityAccum[prefix] = entityAccum[prefix] || {};
+            var prefix = id.split('_')[0]
+            entityAccum[prefix] = entityAccum[prefix] || {}
 
             return benefitIds.reduce((benefitAccum, variable) => {
-                var base = response[group][id][variable];
+                var base = response[group][id][variable]
                 if (base) {
-                    benefitAccum[prefix][variable] = benefitAccum[prefix][variable] || 0;
-                    benefitAccum[prefix][variable] += 1 * (base[periods.thisMonth] || (base[periods.thisYear] / 12) || 0);
+                    benefitAccum[prefix][variable] = benefitAccum[prefix][variable] || 0
+                    benefitAccum[prefix][variable] += 1 * (base[periods.thisMonth] || (base[periods.thisYear] / 12) || 0)
                 }
 
-                return benefitAccum;
-            }, entityAccum);
-        }, groupAccum);
-    }, {});
+                return benefitAccum
+            }, entityAccum)
+        }, groupAccum)
+    }, {})
 }
 
 module.exports = {

--- a/backend/lib/openfisca/bulk/index.js
+++ b/backend/lib/openfisca/bulk/index.js
@@ -1,3 +1,7 @@
+var Promise = require('bluebird');
+var openfisca = Promise.promisifyAll(require('..'));
+var common = require('../mapping/common');
+
 var entityGroups = {
     individus: [],
     familles: ['parents', 'enfants'],
@@ -47,8 +51,61 @@ function append(acummulator, situation) {
     return acummulator;
 }
 
+var defaultValues = [];
+var max = 3500;
+var base = 25;
+var steps = max/base + 1;
+for (var i=0; i<steps; i = i+1) {
+    defaultValues.push(i * max / (steps-1));
+}
+
+function build(situation, variable, values) {
+    values = values || defaultValues
+    var periods = common.getPeriods(situation.dateDeValeur);
+
+    var fullTimePeriodLength = 12*4;
+    var fullTimePeriod = 'month:' + periods['3YearsAgo'] + ':' + fullTimePeriodLength.toString();
+
+    return values.reduce((a, v) => {
+            situation.demandeur[variable] = {};
+            situation.demandeur[variable][fullTimePeriod] = fullTimePeriodLength * v;
+            var ss = openfisca.buildOpenFiscaRequest(situation);
+
+            ss.foyers_fiscaux._.irpp = { [periods.thisYear]: null };
+
+            var prefixed = prefix(v.toString() + '_', ss);
+            return append(a, prefixed);
+        }, init())
+}
+
+function extractResults({ source, response }, benefitIds) {
+    var periods = common.getPeriods(source.dateDeValeur);
+    var entities = ['familles', 'individus', 'foyers_fiscaux', 'menages'];
+
+    return entities.reduce((groupAccum, group) => {
+        var entityNames = Object.keys(response[group]);
+        return entityNames.reduce((entityAccum, id) => {
+            var prefix = id.split('_')[0];
+            entityAccum[prefix] = entityAccum[prefix] || {};
+
+            return benefitIds.reduce((benefitAccum, variable) => {
+                var base = response[group][id][variable];
+                if (base) {
+                    benefitAccum[prefix][variable] = benefitAccum[prefix][variable] || 0;
+                    benefitAccum[prefix][variable] += 1 * (base[periods.thisMonth] || (base[periods.thisYear] / 12) || 0);
+                }
+
+                return benefitAccum;
+            }, entityAccum);
+        }, groupAccum);
+    }, {});
+}
+
 module.exports = {
+    base,
+    build,
+    extractResults,
     init,
     prefix,
     append
-};
+}

--- a/backend/lib/openfisca/mapping/common.js
+++ b/backend/lib/openfisca/mapping/common.js
@@ -55,7 +55,8 @@ exports.getPeriods = function (dateDeValeur) {
         previousFiscalYear12Months: _.map(_.range(12), function(monthIndex) {
             var fiscalYear = moment(dateDeValeur.clone().subtract(3, 'years').year(), 'YYYY');
             return fiscalYear.clone().add(monthIndex, 'months').format('YYYY-MM');
-        })
+        }),
+        '3YearsAgo': dateDeValeur.clone().subtract(3, 'years').format('YYYY-MM'),
     };
 };
 

--- a/tests/unit/openfisca/bulk.spec.js
+++ b/tests/unit/openfisca/bulk.spec.js
@@ -1,0 +1,45 @@
+var {build, extractResults } = require('../../../backend/lib/openfisca/bulk');
+
+const situation = {
+    dateDeValeur: "2021-01",
+    demandeur: {id: 'demandeur'},
+    famille: {},
+    foyer_fiscal: {},
+    menage: {},
+}
+
+describe('openfisca build generation', function() {
+    it('generates a non empty string', function() {
+        const result = build(situation, 'ressource', [0, 1000])
+
+        const collection = result.individus['1000_demandeur'].ressource
+        const value = collection[Object.keys(collection)[0]]
+        expect(value).toBe(1000 * (4 * 12))
+    })
+})
+
+describe('openfisca result extraction', function() {
+    it('generates a non empty string', function() {
+        const result = extractResults({
+            source: {
+                dateDeValeur: '2021-01',
+            },
+            response: {
+                individus: {
+                    "1000_id": {
+                    }
+                },
+                familles: {},
+                menages: {},
+                foyers_fiscaux: {
+                    "1000_": {
+                        irpp: {
+                            "2021": 120
+                        }
+                    }
+                }
+            }
+        }, ['irpp'])
+        expect(result['1000'].irpp).toBe(10)
+    })
+})


### PR DESCRIPTION
François de l'IPP m'a signalé que le montant de l'IRPP était faux pour un célibataire à 2500€/mois. Les ressources n'étaient pas correctement indiquées car la période était figée dans le temps de 2017 à 2020. C'est corrigé et j'ai marginalement restructuré le code pour utiliser des tests.

En production actuellement (c'est complètement faux, le RSA est là tout le temps car en fait il n'y a pas de salaire sur la période considérée)
![Screenshot_2021-01-27 Décomposition du revenu disponible en fonction du salaire net(2)](https://user-images.githubusercontent.com/1410356/106047338-c55d4980-60e3-11eb-8bc0-92b11aa4d52b.png)


Maintenant :
![Screenshot_2021-01-27 Décomposition du revenu disponible en fonction du salaire net(1)](https://user-images.githubusercontent.com/1410356/106047158-87f8bc00-60e3-11eb-9e46-8f55e1061897.png)
